### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tad_dftd3
-version = 0.0.2
+version = 1.0.0
 description = Torch autodiff DFT-D3 implementation
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
The API should be stable enough to release a "non-experimental" version 1.0.0. 