### PR TITLE
Replace `new_tensor`

### DIFF
--- a/src/tad_dftd3/damping/atm.py
+++ b/src/tad_dftd3/damping/atm.py
@@ -60,6 +60,8 @@ def dispersion_atm(
     Tensor
         Atom-resolved ATM dispersion energy.
     """
+    dd = {"device": positions.device, "dtype": positions.dtype}
+
     s9 = s9.type(positions.dtype).to(positions.device)
     rs9 = rs9.type(positions.dtype).to(positions.device)
     alp = alp.type(positions.dtype).to(positions.device)
@@ -85,7 +87,7 @@ def dispersion_atm(
             torch.cdist(
                 positions, positions, p=2, compute_mode="use_mm_for_euclid_dist"
             ),
-            positions.new_tensor(torch.finfo(positions.dtype).eps),
+            torch.tensor(torch.finfo(positions.dtype).eps, **dd),
         ),
         2.0,
     )
@@ -107,7 +109,7 @@ def dispersion_atm(
         * (r2jk <= cutoff2)
         * (r2jk <= cutoff2),
         0.375 * s / r5 + 1.0 / r3,
-        positions.new_tensor(0.0),
+        torch.tensor(0.0, **dd),
     )
 
     energy = ang * fdamp * c9

--- a/src/tad_dftd3/damping/rational.py
+++ b/src/tad_dftd3/damping/rational.py
@@ -43,6 +43,8 @@ def rational_damping(
     Tensor
         Values of the damping function.
     """
-    a1 = param.get("a1", distances.new_tensor(defaults.A1))
-    a2 = param.get("a2", distances.new_tensor(defaults.A1))
+    dd = {"device": distances.device, "dtype": distances.dtype}
+
+    a1 = param.get("a1", torch.tensor(defaults.A1, **dd))
+    a2 = param.get("a2", torch.tensor(defaults.A2, **dd))
     return 1.0 / (distances.pow(order) + (a1 * torch.sqrt(qq) + a2).pow(order))

--- a/src/tad_dftd3/model.py
+++ b/src/tad_dftd3/model.py
@@ -129,7 +129,7 @@ def weight_references(
     weights = torch.where(
         mask,
         weighting_function(reference.cn[numbers] - cn.unsqueeze(-1), **kwargs),
-        cn.new_tensor(0.0),
+        torch.tensor(0.0, device=cn.device, dtype=cn.dtype),
     )
     norms = torch.add(torch.sum(weights, dim=-1), epsilon)
 


### PR DESCRIPTION
Create tensors from floats with

```python
torch.tensor(<float>, device=<tensor>.device, dtype=<tensor>.dtype) 
```

instead of using

```python
<tensor>.new_tensor(<float>) 
```

The latter has side effects (copies additional data beside dtype and device) that become apparent in more advanced AD applications.