### PR TITLE
Make functorch optional

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tad_dftd3
-version = 0.1.1
+version = attr: tad_dftd3.__version__.__version__
 description = Torch autodiff DFT-D3 implementation
 long_description = file: README.rst
 long_description_content_type = text/x-rst

--- a/src/tad_dftd3/__version__.py
+++ b/src/tad_dftd3/__version__.py
@@ -1,0 +1,10 @@
+"""
+Version module for tad_dftd3.
+"""
+import torch
+
+__version__ = "0.1.1"
+
+__torch_version__ = tuple(
+    int(x) for x in torch.__version__.split("+", maxsplit=1)[0].split(".")
+)

--- a/src/tad_dftd3/util.py
+++ b/src/tad_dftd3/util.py
@@ -34,12 +34,12 @@ from .typing import (
     Union,
 )
 
-if __torch_version__ < (2, 0, 0): # pragma: no cover
+if __torch_version__ < (2, 0, 0):  # pragma: no cover
     try:
         from functorch import jacrev  # type: ignore
     except ModuleNotFoundError:
         jacrev = None
-else: # pragma: no cover
+else:  # pragma: no cover
     from torch.func import jacrev  # type: ignore
 
 

--- a/src/tad_dftd3/util.py
+++ b/src/tad_dftd3/util.py
@@ -34,13 +34,12 @@ from .typing import (
     Union,
 )
 
-# pragma: no cover
-if __torch_version__ < (2, 0, 0):
+if __torch_version__ < (2, 0, 0): # pragma: no cover
     try:
         from functorch import jacrev  # type: ignore
     except ModuleNotFoundError:
         jacrev = None
-else:
+else: # pragma: no cover
     from torch.func import jacrev  # type: ignore
 
 

--- a/src/tad_dftd3/util.py
+++ b/src/tad_dftd3/util.py
@@ -34,7 +34,8 @@ from .typing import (
     Union,
 )
 
-if __torch_version__ < (2, 0, 0):  # pragma: no cover
+# pragma: no cover
+if __torch_version__ < (2, 0, 0):
     try:
         from functorch import jacrev  # type: ignore
     except ModuleNotFoundError:
@@ -254,8 +255,9 @@ def jacobian(f: Callable[..., Tensor], argnums: int = 0) -> Any:
     argnums : int, optional
         The variable w.r.t. which will be differentiated. Defaults to 0.
     """
-    if jacrev is None:
+    if jacrev is None:  # pragma: no cover
         raise ModuleNotFoundError("PyTorch's `functorch` is not installed.")
+
     return jacrev(f, argnums=argnums)  # type: ignore
 
 


### PR DESCRIPTION
Avoid requiring PyTorch's `functorch` for `tad_dftd3` to work, as it is not included per default before PyTorch 2.0.0.