### PR TITLE
Fix cov d3 as function call

### DIFF
--- a/src/tad_dftd3/disp.py
+++ b/src/tad_dftd3/disp.py
@@ -136,7 +136,7 @@ def dftd3(
     if ref is None:
         ref = Reference(**dd)
     if rcov is None:
-        rcov = data.COV_D3.to(**dd)[numbers]
+        rcov = data.COV_D3().to(**dd)[numbers]
     if rvdw is None:
         rvdw = data.VDW_D3.to(**dd)[numbers.unsqueeze(-1), numbers.unsqueeze(-2)]
     if r4r2 is None:

--- a/test/test_disp/test_special.py
+++ b/test/test_disp/test_special.py
@@ -38,7 +38,7 @@ def test_single(dtype: torch.dtype, name: str) -> None:
     positions = sample["positions"].to(**dd)
     ref = sample["disp2"].to(**dd)
 
-    rcov = data.COV_D3.to(**dd)[numbers]
+    rcov = data.COV_D3().to(**dd)[numbers]
     rvdw = data.VDW_D3.to(**dd)[numbers.unsqueeze(-1), numbers.unsqueeze(-2)]
     r4r2 = data.R4R2.to(**dd)[numbers]
     cutoff = torch.tensor(50, **dd)


### PR DESCRIPTION
As I reported as in the [issue](https://github.com/dftd3/tad-dftd3/issues/87), the current main branch encountered an error because the data.COV_D3 in tad-mctc library was changed from Tensor to lru_cached function in this [commit](https://github.com/tad-mctc/tad-mctc/commit/31d93780a86ea54b949c041eed91ac3b55afc57e).
 
 This is the quick fix to avoid this error. I have confirmed that it passes Pytest. 